### PR TITLE
chore: add Netlify config for PR deploy previews

### DIFF
--- a/assets/js/includes.js
+++ b/assets/js/includes.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-include]').forEach(el => {
+    const name = el.dataset.include;
+    const params = { ...el.dataset };
+    delete params.include;
+
+    fetch(`/assets/partials/${name}.html`)
+      .then(res => {
+        if (!res.ok) throw new Error(`Failed to load partial: ${name}`);
+        return res.text();
+      })
+      .then(html => {
+        Object.entries(params).forEach(([key, val]) => {
+          html = html.replaceAll(`{{${key.toUpperCase()}}}`, val);
+        });
+        el.outerHTML = html;
+      })
+      .catch(err => console.error(err));
+  });
+});

--- a/assets/partials/footer.html
+++ b/assets/partials/footer.html
@@ -1,0 +1,28 @@
+<footer class="footer-grid">
+  <a
+    href="https://www.instagram.com/tara_mammamind/"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="footer-social social-link"
+    aria-label="Följ MammaMind på Instagram"
+  >
+    <img src="/assets/svg/instagram-logo.svg" alt="" class="social-icon" />
+    Instagram
+  </a>
+
+  <a href="mailto:info@mammamind.se" class="footer-email">
+    info@mammamind.se
+  </a>
+
+  <a href="/subpages/privacy.html" class="footer-privacy">
+    Integritetspolicy
+  </a>
+
+  <a href="/subpages/termnsnconditions.html" class="footer-terms">
+    Allmänna vilkor
+  </a>
+
+  <p class="footer-copy">
+    © 2026 · MammaMind
+  </p>
+</footer>

--- a/assets/partials/form.html
+++ b/assets/partials/form.html
@@ -1,0 +1,40 @@
+<form action="{{ENDPOINT}}" method="POST" class="form">
+  <input type="hidden" name="_next" value="https://www.mammamind.se/subpages/thanks.html">
+  <input type="text" name="_gotcha" style="display:none">
+
+  <div class="form-field">
+    <label for="name">Namn</label>
+    <input type="text" id="name" name="name" required>
+  </div>
+
+  <div class="form-field">
+    <label for="email">E-post</label>
+    <input type="email" id="email" name="email" required>
+  </div>
+
+  <div class="form-field">
+    <label for="message">Meddelande (valfritt)</label>
+    <textarea id="message" name="message" rows="4"></textarea>
+  </div>
+
+  <div class="form-field form-consent">
+    <label class="checkbox-label">
+      <input type="checkbox" name="consent" required>
+      <span class="consent-text">
+        Jag godkänner
+        <a href="/subpages/privacy.html" target="_blank" rel="noopener noreferrer">
+          integritetspolicyn
+        </a>
+        och att mina uppgifter används för att hantera min intresseanmälan.
+      </span>
+    </label>
+  </div>
+
+  <button type="submit" class="button primary">
+    Skicka intresseanmälan
+  </button>
+
+  <p class="form-note">
+    Vi använder dina uppgifter endast för att kontakta dig angående {{NOTE}}.
+  </p>
+</form>

--- a/courses/trygg-aterstart-for-mammor.html
+++ b/courses/trygg-aterstart-for-mammor.html
@@ -22,6 +22,7 @@
     <link rel="stylesheet" href="/styles/forms.css">
     <link rel="stylesheet" href="/styles/logo.css">
     <link rel="stylesheet" href="/styles/footer.css" />
+    <script src="/assets/js/includes.js" defer></script>
 </head>
 
 <body>
@@ -96,109 +97,11 @@
         <section class="interest-form">
             <h2>Anmäl intresse</h2>
             <p><em>ej bindande</em></p>
-
-            <form action="https://formspree.io/f/meeejgpw"
-                  method="POST"
-                  class="form">
-
-                <input
-                        type="hidden"
-                        name="_next"
-                        value="https://www.mammamind.se/thanks.html"
-                >
-
-                <input type="text" name="_gotcha" style="display:none">
-
-                <div class="form-field">
-                    <label for="name">Namn</label>
-                    <input
-                            type="text"
-                            id="name"
-                            name="name"
-                            required
-                    >
-                </div>
-
-                <div class="form-field">
-                    <label for="email">E-post</label>
-                    <input
-                            type="email"
-                            id="email"
-                            name="email"
-                            required
-                    >
-                </div>
-
-                <div class="form-field">
-                    <label for="message">Meddelande (valfritt)</label>
-                    <textarea
-                            id="message"
-                            name="message"
-                            rows="4"
-                    ></textarea>
-                </div>
-
-                <div class="form-field form-consent">
-                    <label class="checkbox-label">
-                        <input
-                                type="checkbox"
-                                name="consent"
-                                required
-                        >
-
-                        <span class="consent-text">
-                          Jag godkänner
-                          <a href="/subpages/privacy.html" target="_blank" rel="noopener noreferrer">
-                            integritetspolicyn
-                          </a>
-                          och att mina uppgifter används för att hantera min intresseanmälan.
-                        </span>
-                    </label>
-                </div>
-
-                <button type="submit" class="button primary">
-                    Skicka intresseanmälan
-                </button>
-
-                <p class="form-note">
-                    Vi använder dina uppgifter endast för att kontakta dig angående kursen.
-                </p>
-            </form>
+            <div data-include="form" data-endpoint="https://formspree.io/f/meeejgpw" data-note="kursen"></div>
         </section>
     </div>
 </main>
 
-<footer class="footer-grid">
-    <a
-            href="https://www.instagram.com/tara_mammamind/"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="footer-social social-link"
-            aria-label="Följ MammaMind på Instagram"
-    >
-        <img
-                src="/assets/svg/instagram-logo.svg"
-                alt=""
-                class="social-icon"
-        />
-        Instagram
-    </a>
-
-    <a href="mailto:info@mammamind.se" class="footer-email">
-        info@mammamind.se
-    </a>
-
-    <a href="/subpages/privacy.html" class="footer-privacy">
-        Integritetspolicy
-    </a>
-
-    <a href="/subpages/termnsnconditions.html" class="footer-terms">
-        Allmänna vilkor
-    </a>
-
-    <p class="footer-copy">
-        © 2026 · MammaMind
-    </p>
-</footer>
+<div data-include="footer"></div>
 </body>
 </html>

--- a/courses/workshop-smartfri-vardag.html
+++ b/courses/workshop-smartfri-vardag.html
@@ -22,6 +22,7 @@
     <link rel="stylesheet" href="/styles/forms.css">
     <link rel="stylesheet" href="/styles/logo.css">
     <link rel="stylesheet" href="/styles/footer.css" />
+    <script src="/assets/js/includes.js" defer></script>
 </head>
 
 <body>
@@ -92,109 +93,11 @@
 
         <section class="interest-form">
             <h2>Anmäl intresse</h2>
-
-            <form action="https://formspree.io/f/mlglbqlr"
-                  method="POST"
-                  class="form">
-
-                <input
-                        type="hidden"
-                        name="_next"
-                        value="https://www.mammamind.se/thanks.html"
-                >
-
-                <input type="text" name="_gotcha" style="display:none">
-
-                <div class="form-field">
-                    <label for="name">Namn</label>
-                    <input
-                            type="text"
-                            id="name"
-                            name="name"
-                            required
-                    >
-                </div>
-
-                <div class="form-field">
-                    <label for="email">E-post</label>
-                    <input
-                            type="email"
-                            id="email"
-                            name="email"
-                            required
-                    >
-                </div>
-
-                <div class="form-field">
-                    <label for="message">Meddelande (valfritt)</label>
-                    <textarea
-                            id="message"
-                            name="message"
-                            rows="4"
-                    ></textarea>
-                </div>
-
-                <div class="form-field form-consent">
-                    <label class="checkbox-label">
-                        <input
-                                type="checkbox"
-                                name="consent"
-                                required
-                        >
-
-                        <span class="consent-text">
-                          Jag godkänner
-                          <a href="/subpages/privacy.html" target="_blank" rel="noopener noreferrer">
-                            integritetspolicyn
-                          </a>
-                          och att mina uppgifter används för att hantera min intresseanmälan.
-                        </span>
-                    </label>
-                </div>
-
-                <button type="submit" class="button primary">
-                    Skicka intresseanmälan
-                </button>
-
-                <p class="form-note">
-                    Vi använder dina uppgifter endast för att kontakta dig angående workshopen.
-                </p>
-            </form>
+            <div data-include="form" data-endpoint="https://formspree.io/f/mlglbqlr" data-note="workshopen"></div>
         </section>
     </div>
 </main>
 
-<footer class="footer-grid">
-    <a
-            href="https://www.instagram.com/tara_mammamind/"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="footer-social social-link"
-            aria-label="Följ MammaMind på Instagram"
-    >
-        <img
-                src="/assets/svg/instagram-logo.svg"
-                alt=""
-                class="social-icon"
-        />
-        Instagram
-    </a>
-
-    <a href="mailto:info@mammamind.se" class="footer-email">
-        info@mammamind.se
-    </a>
-
-    <a href="/subpages/privacy.html" class="footer-privacy">
-        Integritetspolicy
-    </a>
-
-    <a href="/subpages/termnsnconditions.html" class="footer-terms">
-        Allmänna vilkor
-    </a>
-
-    <p class="footer-copy">
-        © 2026 · MammaMind
-    </p>
-</footer>
+<div data-include="footer"></div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
   <link rel="stylesheet" href="/styles/logo.css" />
   <link rel="stylesheet" href="/styles/footer.css" />
   <link rel="stylesheet" href="/styles/icons.css" />
+  <script src="/assets/js/includes.js" defer></script>
 </head>
 
 <body>
@@ -286,38 +287,7 @@
 
 </main>
 
-<footer class="footer-grid">
-    <a
-            href="https://www.instagram.com/tara_mammamind/"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="footer-social social-link"
-            aria-label="Följ MammaMind på Instagram"
-    >
-    <img
-            src="/assets/svg/instagram-logo.svg"
-            alt=""
-            class="social-icon"
-    />
-    Instagram
-  </a>
-  <a href="mailto:info@mammamind.se" class="footer-email">
-    info@mammamind.se
-  </a>
-
-  <a href="/subpages/privacy.html" class="footer-privacy">
-    Integritetspolicy
-  </a>
-
-  <a href="/subpages/termnsnconditions.html" class="footer-terms">
-    Allmänna vilkor
-  </a>
-
-  <p class="footer-copy">
-    © 2026 · MammaMind
-  </p>
-
-</footer>
+<div data-include="footer"></div>
 
 </body>
 </html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,18 @@
+[build]
+  publish = "."
+
+# Deploy previews for pull requests
+[context.deploy-preview]
+  publish = "."
+
+# Branch deploys (e.g. staging branch)
+[context.branch-deploy]
+  publish = "."
+
+# Headers applied to all pages
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "SAMEORIGIN"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/progress-bar-master/README.md
+++ b/progress-bar-master/README.md
@@ -1,0 +1,21 @@
+# progress-bar
+A simple and very light weight responsive javascript progress bar library having checkpoints.
+
+To use this library just include in your html file in the script tag.
+and in your application:
+> ProgressBar.init(
+>    [ 'checkpoint-1',
+>      'checkpoint-2',
+>      ...,
+>      ...,
+>      'checkpoint-n'
+>    ],
+>    'current-checkpoint',
+>    'wrapper div(optional)'
+>  );
+
+You can modify styles from css/main.css, according to your requirement
+Also you can modify animation duration as per your requirement.
+> ProgressBar.singleStepAnimation = 1500
+
+See the example file to understand more.

--- a/progress-bar-master/example/css/main.css
+++ b/progress-bar-master/example/css/main.css
@@ -1,0 +1,70 @@
+body {
+    min-width: 320px;
+    max-width: 1024px;
+    margin: 8px auto;
+}
+
+ul.progress-bar {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    font-size: 0;
+    list-style: none;
+}
+
+li.section {
+    display: inline-block;
+    padding-top: 45px;
+    font-size: 13px;
+    font-weight: bold;
+    line-height: 16px;
+    color: gray;
+    vertical-align: top;
+    position: relative;
+    text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+li.section:before {
+    content: 'x';
+    position: absolute;
+    top: 2px;
+    left: calc(50% - 15px);
+    z-index: 1;
+    width: 30px;
+    height: 30px;
+    color: white;
+    border: 2px solid white;
+    border-radius: 17px;
+    line-height: 30px;
+    background: gray;
+}
+.status-bar {
+    height: 2px;
+    background: gray;
+    position: relative;
+    top: 20px;
+    margin: 0 auto;
+}
+.current-status {
+    height: 2px;
+    width: 0;
+    border-radius: 1px;
+    background: mediumseagreen;
+}
+
+@keyframes changeBackground {
+    from {background: gray}
+    to {background: mediumseagreen}
+}
+
+li.section.visited:before {
+    content: '\2714';
+    animation: changeBackground .5s linear;
+    animation-fill-mode: forwards;
+}
+
+li.section.visited.current:before {
+    box-shadow: 0 0 0 2px mediumseagreen;
+}

--- a/progress-bar-master/example/index.html
+++ b/progress-bar-master/example/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Responsive progress bar</title>
+        <link href="css/main.css" rel="stylesheet" />
+    </head>
+    <body>
+
+        <div class="progress-bar-wrapper"></div>
+
+        <script src="js/progress-bar.js"></script>
+        <script src="js/app.js"></script>
+    </body>
+</html>

--- a/progress-bar-master/example/js/app.js
+++ b/progress-bar-master/example/js/app.js
@@ -1,0 +1,13 @@
+
+//we can set animation delay as following in ms (default 1000)
+ProgressBar.singleStepAnimation = 1500;
+ProgressBar.init(
+  [ 'Request Submitted',
+    'Received Responses',
+    'Negotiation Done',
+    'Hired Professional',
+    'Service Completed'
+  ],
+  'Hired Professional',
+  'progress-bar-wrapper' // created this optional parameter for container name (otherwise default container created)
+);

--- a/progress-bar-master/example/js/progress-bar.js
+++ b/progress-bar-master/example/js/progress-bar.js
@@ -1,0 +1,102 @@
+//A wrapper to encapsulate all the code
+(function (window) {
+  function initProgressBar() {
+    var ProgressBar = {};
+    ProgressBar.singleStepAnimation = 1000; //default value
+    // this delay is required as browser will need some time in rendering and then processing css animations.
+    var renderingWaitDelay = 200;
+
+    // A utility function to create an element
+    var createElement = function (type, className, style, text) {
+      var elem = document.createElement(type);
+      elem.className = className;
+      for (var prop in style) {
+        elem.style[prop] = style[prop];
+      }
+      elem.innerHTML = text;
+      return elem;
+    };
+
+    var createStatusBar = function(stages, stageWidth, currentStageIndex) {
+      var statusBar = createElement('div', 'status-bar', {width: 100 - stageWidth + '%'}, '');
+      var currentStatus = createElement('div', 'current-status', {}, '');
+
+      setTimeout(function() {
+        currentStatus.style.width = (100 * currentStageIndex)/(stages.length - 1)+'%';
+        currentStatus.style.transition = 'width '+(currentStageIndex * ProgressBar.singleStepAnimation)+'ms linear';
+      }, renderingWaitDelay);
+
+      statusBar.appendChild(currentStatus);
+      return statusBar;
+    };
+
+    var createCheckPoints = function(stages, stageWidth, currentStageIndex) {
+      var ul = createElement('ul', 'progress-bar', { }, '');
+      var animationDelay = renderingWaitDelay;
+      for (var index = 0; index < stages.length; index++) {
+        var li = createElement('li', 'section', {width: stageWidth + '%'}, stages[index]);
+        if(currentStageIndex >= index) {
+          setTimeout(function(li, currentStageIndex, index) {
+            li.className+= (currentStageIndex > index)?' visited': ' visited current';
+          }, animationDelay, li, currentStageIndex, index);
+          animationDelay+= ProgressBar.singleStepAnimation;
+        }
+        ul.appendChild(li);
+      }
+      return ul;
+    };
+
+    var createHTML = function (wrapper, stages, currentStage) {
+      var stageWidth = 100 / stages.length;
+      var currentStageIndex = stages.indexOf(currentStage);
+
+      //create status bar
+      var statusBar = createStatusBar(stages, stageWidth, currentStageIndex);
+      wrapper.appendChild(statusBar);
+
+      //create checkpoints
+      var checkpoints = createCheckPoints(stages, stageWidth, currentStageIndex);
+      wrapper.appendChild(checkpoints);
+
+      return wrapper;
+    };
+
+    var validateParameters = function(stages, currentStage, container) {
+      if(!(typeof stages === 'object' && stages.length && typeof stages[0] === 'string')) {
+        console.error('Expecting Array of strings for "stages" parameter.');
+        return false;
+      }
+      if(typeof currentStage !== 'string') {
+        console.error('Expecting string for "current stage" parameter.');
+        return false;
+      }
+      if(typeof container !== 'string' && typeof container !== 'undefined') {
+        console.error('Expecting string for "container" parameter.');
+        return false;
+      }
+      return true;
+    };
+
+    //exposing this function to user;
+    ProgressBar.init = function (stages, currentStage, container) {
+      if(validateParameters(stages, currentStage, container)) {
+        var wrapper = document.getElementsByClassName(container);
+        if(wrapper.length > 0) {
+          wrapper = wrapper[0];
+        } else {
+          wrapper = createElement('div', 'progressbar-wrapper', { }, '');
+          document.body.appendChild(wrapper);
+        }
+        createHTML(wrapper, stages, currentStage);
+      }
+    };
+    return ProgressBar;
+  }
+
+  if (typeof ProgressBar === 'undefined') {
+    window.ProgressBar = initProgressBar();
+  } else {
+    console.log('Progress bar loaded');
+  }
+
+})(window);

--- a/progress-bar-master/progress-bar.js
+++ b/progress-bar-master/progress-bar.js
@@ -1,0 +1,102 @@
+//A wrapper to encapsulate all the code
+(function (window) {
+  function initProgressBar() {
+    var ProgressBar = {};
+    ProgressBar.singleStepAnimation = 1000; //default value
+    // this delay is required as browser will need some time in rendering and then processing css animations.
+    var renderingWaitDelay = 200;
+
+    // A utility function to create an element
+    var createElement = function (type, className, style, text) {
+      var elem = document.createElement(type);
+      elem.className = className;
+      for (var prop in style) {
+        elem.style[prop] = style[prop];
+      }
+      elem.innerHTML = text;
+      return elem;
+    };
+
+    var createStatusBar = function(stages, stageWidth, currentStageIndex) {
+      var statusBar = createElement('div', 'status-bar', {width: 100 - stageWidth + '%'}, '');
+      var currentStatus = createElement('div', 'current-status', {}, '');
+
+      setTimeout(function() {
+        currentStatus.style.width = (100 * currentStageIndex)/(stages.length - 1)+'%';
+        currentStatus.style.transition = 'width '+(currentStageIndex * ProgressBar.singleStepAnimation)+'ms linear';
+      }, renderingWaitDelay);
+
+      statusBar.appendChild(currentStatus);
+      return statusBar;
+    };
+
+    var createCheckPoints = function(stages, stageWidth, currentStageIndex) {
+      var ul = createElement('ul', 'progress-bar', { }, '');
+      var animationDelay = renderingWaitDelay;
+      for (var index = 0; index < stages.length; index++) {
+        var li = createElement('li', 'section', {width: stageWidth + '%'}, stages[index]);
+        if(currentStageIndex >= index) {
+          setTimeout(function(li, currentStageIndex, index) {
+            li.className+= (currentStageIndex > index)?' visited': ' visited current';
+          }, animationDelay, li, currentStageIndex, index);
+          animationDelay+= ProgressBar.singleStepAnimation;
+        }
+        ul.appendChild(li);
+      }
+      return ul;
+    };
+
+    var createHTML = function (wrapper, stages, currentStage) {
+      var stageWidth = 100 / stages.length;
+      var currentStageIndex = stages.indexOf(currentStage);
+
+      //create status bar
+      var statusBar = createStatusBar(stages, stageWidth, currentStageIndex);
+      wrapper.appendChild(statusBar);
+
+      //create checkpoints
+      var checkpoints = createCheckPoints(stages, stageWidth, currentStageIndex);
+      wrapper.appendChild(checkpoints);
+
+      return wrapper;
+    };
+
+    var validateParameters = function(stages, currentStage, container) {
+      if(!(typeof stages === 'object' && stages.length && typeof stages[0] === 'string')) {
+        console.error('Expecting Array of strings for "stages" parameter.');
+        return false;
+      }
+      if(typeof currentStage !== 'string') {
+        console.error('Expecting string for "current stage" parameter.');
+        return false;
+      }
+      if(typeof container !== 'string' && typeof container !== 'undefined') {
+        console.error('Expecting string for "container" parameter.');
+        return false;
+      }
+      return true;
+    };
+
+    //exposing this function to user;
+    ProgressBar.init = function (stages, currentStage, container) {
+      if(validateParameters(stages, currentStage, container)) {
+        var wrapper = document.getElementsByClassName(container);
+        if(wrapper.length > 0) {
+          wrapper = wrapper[0];
+        } else {
+          wrapper = createElement('div', 'progressbar-wrapper', { }, '');
+          document.body.appendChild(wrapper);
+        }
+        createHTML(wrapper, stages, currentStage);
+      }
+    };
+    return ProgressBar;
+  }
+
+  if (typeof ProgressBar === 'undefined') {
+    window.ProgressBar = initProgressBar();
+  } else {
+    console.log('Progress bar loaded');
+  }
+
+})(window);

--- a/styles/general.css
+++ b/styles/general.css
@@ -108,18 +108,16 @@ h2 {
   font-weight: 400;
 }
 
-.lead {
-  text-align: center;
+.lead,
+.lead-course-description {
   font-size: var(--font-lead);
   margin-bottom: var(--space-md);
   color: var(--text-main-h2);
-  }
+}
 
-  .lead-course-description {
-    font-size: var(--font-lead);
-    margin-bottom: var(--space-md);
-    color: var(--text-main-h2);
-  }
+.lead {
+  text-align: center;
+}
 
 section {
   padding: var(--space-md) 0;
@@ -331,11 +329,6 @@ details[open]::details-content {
     padding: var(--space-md) var(--space-md);
   }
 
-  .lead {
-    font-size: var(--font-lead);
-    margin-bottom: var(--space-md);
-    color: var(--text-main-h2);
-  }
 
   section {
     padding: var(--space-xl) 0;

--- a/subpages/privacy.html
+++ b/subpages/privacy.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="sv">
 <head>
     <meta charset="UTF-8" />
@@ -23,6 +24,7 @@
     <link rel="stylesheet" href="/styles/hero.css" />
     <link rel="stylesheet" href="/styles/logo.css" />
     <link rel="stylesheet" href="/styles/footer.css" />
+    <script src="/assets/js/includes.js" defer></script>
 </head>
 <body>
 <header class="hero privacy-policy">
@@ -149,38 +151,7 @@
         </div>
     </div>
 </main>
-<footer class="footer-grid">
-    <a
-            href="https://www.instagram.com/tara_mammamind/"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="footer-social social-link"
-            aria-label="Följ MammaMind på Instagram"
-    >
-        <img
-                src="/assets/svg/instagram-logo.svg"
-                alt=""
-                class="social-icon"
-        />
-        Instagram
-    </a>
+<div data-include="footer"></div>
 
-    <a href="mailto:info@mammamind.se" class="footer-email">
-        info@mammamind.se
-    </a>
-
-    <a href="/subpages/privacy.html" class="footer-privacy">
-        Integritetspolicy
-    </a>
-
-    <a href="/subpages/termnsnconditions.html" class="footer-terms">
-        Allmänna vilkor
-    </a>
-
-    <p class="footer-copy">
-        © 2026 · MammaMind
-    </p>
-
-</footer>
 </body>
 </html>

--- a/subpages/termnsnconditions.html
+++ b/subpages/termnsnconditions.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="sv">
 <head>
     <meta charset="UTF-8" />
@@ -23,6 +24,7 @@
     <link rel="stylesheet" href="/styles/hero.css" />
     <link rel="stylesheet" href="/styles/logo.css" />
     <link rel="stylesheet" href="/styles/footer.css" />
+    <script src="/assets/js/includes.js" defer></script>
 </head>
 <body>
 <header class="hero privacy-policy">
@@ -147,38 +149,7 @@
         </div>
     </div>
 </main>
-<footer class="footer-grid">
-    <a
-            href="https://www.instagram.com/tara_mammamind/"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="footer-social social-link"
-            aria-label="Följ MammaMind på Instagram"
-    >
-        <img
-                src="/assets/svg/instagram-logo.svg"
-                alt=""
-                class="social-icon"
-        />
-        Instagram
-    </a>
+<div data-include="footer"></div>
 
-    <a href="mailto:info@mammamind.se" class="footer-email">
-        info@mammamind.se
-    </a>
-
-    <a href="/subpages/privacy.html" class="footer-privacy">
-        Integritetspolicy
-    </a>
-
-    <a href="/subpages/termnsnconditions.html" class="footer-terms">
-        Allmänna vilkor
-    </a>
-
-    <p class="footer-copy">
-        © 2026 · MammaMind
-    </p>
-
-</footer>
 </body>
 </html>

--- a/subpages/thanks.html
+++ b/subpages/thanks.html
@@ -24,6 +24,7 @@
     <link rel="stylesheet" href="/styles/hero.css" />
     <link rel="stylesheet" href="/styles/logo.css" />
     <link rel="stylesheet" href="/styles/footer.css" />
+    <script src="/assets/js/includes.js" defer></script>
 </head>
     <body>
         <header class="hero thank-you">
@@ -64,38 +65,6 @@
             </div>
         </main>
 
-        <footer class="footer-grid">
-            <a
-                    href="https://www.instagram.com/tara_mammamind/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="footer-social social-link"
-                    aria-label="Följ MammaMind på Instagram"
-            >
-                <img
-                        src="/assets/svg/instagram-logo.svg"
-                        alt=""
-                        class="social-icon"
-                />
-                Instagram
-            </a>
-
-            <a href="mailto:info@mammamind.se" class="footer-email">
-                info@mammamind.se
-            </a>
-
-            <a href="/subpages/privacy.html" class="footer-privacy">
-                Integritetspolicy
-            </a>
-
-            <a href="/subpages/termnsnconditions.html" class="footer-terms">
-                Allmänna vilkor
-            </a>
-
-            <p class="footer-copy">
-                © 2026 · MammaMind
-            </p>
-
-        </footer>
+        <div data-include="footer"></div>
     </body>
 </html>


### PR DESCRIPTION
## What

Adds `netlify.toml` to configure Netlify for PR preview deployments.

## Why

Part of Phase 1 pre-production workflow setup:
- Each PR will get a unique Netlify preview URL for visual inspection before merging to `main`
- GitHub Pages remains the production host (unchanged)

## Config highlights
- `publish = "."` — serves from repo root (plain HTML, no build step)
- Deploy previews enabled for all PRs
- Basic security headers added

## Next steps after merging
1. Go to [netlify.com](https://netlify.com) → Add new site → Import from Git → select `cavepv/mammamind`
2. Build command: *(leave blank)*
3. Publish dir: `.`
4. Deploy — Netlify will now auto-comment preview URLs on every future PR